### PR TITLE
disable audience verification if audience not configured

### DIFF
--- a/flask_jwt_consumer/decorators.py
+++ b/flask_jwt_consumer/decorators.py
@@ -23,6 +23,8 @@ def requires_jwt(f):
                     jwt_config.update({
                         'audience': config.audience
                     })
+                else:
+                    jwt_config.update({options: {'verify_aud': False}})
                 payload = jwt.decode(
                     token,
                     key,

--- a/flask_jwt_consumer/decorators.py
+++ b/flask_jwt_consumer/decorators.py
@@ -24,7 +24,7 @@ def requires_jwt(f):
                         'audience': config.audience
                     })
                 else:
-                    jwt_config.update({options: {'verify_aud': False}})
+                    jwt_config.update({'options': {'verify_aud': False}})
                 payload = jwt.decode(
                     token,
                     key,

--- a/tests/base/test_config_identity.py
+++ b/tests/base/test_config_identity.py
@@ -140,11 +140,7 @@ class TestExtensionJWTConsumer:
             with mock.patch('flask_jwt_consumer.decorators._brute_force_key',
                             return_value=JWT_PUBLIC_KEY):
                 protected = requires_jwt(identity)
-                with pytest.raises(AuthError) as err:
-                    protected('De nada')
-                assert err.value.code == 401
-                assert err.value.content == {'code': 'invalid_claims',
-                                        'description': 'Incorrect claims, please check the issued at, audience or issuer.'} != {'description': 'Missing claims, please check the audience.'}
+                assert protected('De nada') == 'De nada'
 
     def test_jwt_requies_jwt_no_aud_token_no_identity(self, live_testapp_no_identity):
         """No identity and no aud just works"""


### PR DESCRIPTION
this change ensures that even if a claim contains an `audience` list, when a consuming service does not set `JWT_IDENTITY` for flask-jwt-consumer, `audience` will be ignored.