### PR TITLE
Use Py38 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/python:3.6.6
+    - image: circleci/python:3.8
   working_directory: ~/flask-jwt-consumer
 
 jobs:


### PR DESCRIPTION
pytest uses a hack for a problem with importlib in 3.6 and 3.7,
but it doesn't always apply cleanly. Just updating to 3.8
works around the problem.

https://github.com/pytest-dev/pytest/blob/master/setup.cfg#L52